### PR TITLE
Adds recently added local songs feature

### DIFF
--- a/app/src/main/java/com/sdsmdg/harjot/MusicDNA/activities/HomeActivity.java
+++ b/app/src/main/java/com/sdsmdg/harjot/MusicDNA/activities/HomeActivity.java
@@ -1548,9 +1548,11 @@ public class HomeActivity extends AppCompatActivity
                 if (duration > 10000) {
                     LocalTrack lt = new LocalTrack(thisId, thisTitle, thisArtist, thisAlbum, path, duration);
                     localTrackList.add(lt);
-                    recentlyAddedTrackList.add(lt);
                     finalLocalSearchResultList.add(lt);
-                    finalRecentlyAddedTrackSearchResultList.add(lt);
+                    if (recentlyAddedTrackList.size() <= 50) {
+                        recentlyAddedTrackList.add(lt);
+                        finalRecentlyAddedTrackSearchResultList.add(lt);
+                    }
 
                     int pos;
                     if (thisAlbum != null) {

--- a/app/src/main/java/com/sdsmdg/harjot/MusicDNA/fragments/LocalMusicFragments/LocalMusicViewPagerFragment.java
+++ b/app/src/main/java/com/sdsmdg/harjot/MusicDNA/fragments/LocalMusicFragments/LocalMusicViewPagerFragment.java
@@ -134,7 +134,7 @@ public class LocalMusicViewPagerFragment extends Fragment {
         adapter.addFragment(new LocalMusicFragment(), "Songs");
         adapter.addFragment(new AlbumFragment(), "Albums");
         adapter.addFragment(new ArtistFragment(), "Artists");
-
+        adapter.addFragment(new RecentlyAddedSongsFragment(), "Recent");
     }
 
     class MyPageAdapter extends FragmentPagerAdapter {

--- a/app/src/main/java/com/sdsmdg/harjot/MusicDNA/fragments/LocalMusicFragments/RecentlyAddedSongsFragment.java
+++ b/app/src/main/java/com/sdsmdg/harjot/MusicDNA/fragments/LocalMusicFragments/RecentlyAddedSongsFragment.java
@@ -1,0 +1,230 @@
+package com.sdsmdg.harjot.MusicDNA.fragments.LocalMusicFragments;
+
+
+//import android.app.Fragment;
+
+import android.content.res.ColorStateList;
+import android.graphics.Color;
+import android.os.Handler;
+import android.support.design.widget.FloatingActionButton;
+import android.support.v4.app.Fragment;
+import android.content.Context;
+import android.os.Bundle;
+import android.support.v7.widget.DefaultItemAnimator;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.animation.OvershootInterpolator;
+import android.widget.Button;
+import android.widget.RelativeLayout;
+
+import com.github.amlcurran.showcaseview.ShowcaseView;
+import com.github.amlcurran.showcaseview.targets.ViewTarget;
+import com.sdsmdg.harjot.MusicDNA.clickitemtouchlistener.ClickItemTouchListener;
+import com.sdsmdg.harjot.MusicDNA.custombottomsheets.CustomLocalBottomSheetDialog;
+import com.sdsmdg.harjot.MusicDNA.activities.HomeActivity;
+import com.sdsmdg.harjot.MusicDNA.fragments.ViewPlaylistFragment.PlaylistTrackAdapter;
+import com.sdsmdg.harjot.MusicDNA.models.LocalTrack;
+import com.sdsmdg.harjot.MusicDNA.models.Playlist;
+import com.sdsmdg.harjot.MusicDNA.models.UnifiedTrack;
+import com.sdsmdg.harjot.MusicDNA.MusicDNAApplication;
+import com.sdsmdg.harjot.MusicDNA.R;
+import com.sdsmdg.harjot.MusicDNA.utilities.CommonUtils;
+import com.squareup.leakcanary.RefWatcher;
+
+import java.util.Random;
+
+
+/**
+ * A simple {@link Fragment} subclass.
+ */
+public class RecentlyAddedSongsFragment extends Fragment {
+
+    LocalTrackRecyclerAdapter adapter;
+    OnLocalTrackSelectedListener mCallback;
+    Context ctx;
+
+    ShowcaseView showCase;
+
+    RecyclerView lv;
+    LinearLayoutManager mLayoutManager2;
+
+    FloatingActionButton playAllFAB;
+
+    HomeActivity activity;
+
+    View bottomMarginLayout;
+
+    public interface OnLocalTrackSelectedListener {
+        void onLocalTrackSelected(int position);
+    }
+
+    public RecentlyAddedSongsFragment() {
+        // Required empty public constructor
+    }
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        try {
+            mCallback = (OnLocalTrackSelectedListener) context;
+        } catch (ClassCastException e) {
+            throw new ClassCastException(context.toString()
+                    + " must implement OnHeadlineSelectedListener");
+        }
+        ctx = context;
+        activity = (HomeActivity) context;
+    }
+
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_recently_added_songs, container, false);
+    }
+
+    @Override
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        bottomMarginLayout = view.findViewById(R.id.bottom_margin_layout);
+        if (HomeActivity.isReloaded) {
+            bottomMarginLayout.getLayoutParams().height = 0;
+        } else {
+            bottomMarginLayout.getLayoutParams().height = CommonUtils.dpTopx(65, getContext());
+        }
+
+        playAllFAB = (FloatingActionButton) view.findViewById(R.id.play_all_fab_local);
+
+        if (HomeActivity.recentlyAddedTrackList.size() == 0) {
+            playAllFAB.setVisibility(View.INVISIBLE);
+        }
+
+        playAllFAB.setBackgroundTintList(ColorStateList.valueOf(HomeActivity.themeColor));
+        playAllFAB.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                HomeActivity.queue.getQueue().clear();
+                for (int i = 0; i < HomeActivity.recentlyAddedTrackList.size(); i++) {
+                    UnifiedTrack ut = new UnifiedTrack(true, HomeActivity.recentlyAddedTrackList.get(i), null);
+                    HomeActivity.queue.getQueue().add(ut);
+                }
+                HomeActivity.queueCurrentIndex = 0;
+                LocalTrack track = HomeActivity.recentlyAddedTrackList.get(0);
+                HomeActivity.localSelectedTrack = track;
+                HomeActivity.streamSelected = false;
+                HomeActivity.localSelected = true;
+                HomeActivity.queueCall = false;
+                HomeActivity.isReloaded = false;
+                mCallback.onLocalTrackSelected(-1);
+            }
+        });
+
+        lv = (RecyclerView) view.findViewById(R.id.recentlyAddedLocalMusicList);
+        adapter = new LocalTrackRecyclerAdapter(HomeActivity.finalRecentlyAddedTrackSearchResultList, getContext());
+        mLayoutManager2 = new LinearLayoutManager(getContext(), LinearLayoutManager.VERTICAL, false);
+        lv.setLayoutManager(mLayoutManager2);
+        lv.setItemAnimator(new DefaultItemAnimator());
+        lv.setAdapter(adapter);
+
+        lv.addOnItemTouchListener(new ClickItemTouchListener(lv) {
+            @Override
+            public boolean onClick(RecyclerView parent, View view, int position, long id) {
+
+                if (position >= 0) {
+                    HomeActivity.queue.getQueue().clear();
+                    for (int i = 0; i < HomeActivity.recentlyAddedTrackList.size(); i++) {
+                        UnifiedTrack ut = new UnifiedTrack(true, HomeActivity.recentlyAddedTrackList.get(i), null);
+                        HomeActivity.queue.getQueue().add(ut);
+                    }
+                    HomeActivity.queueCurrentIndex = getPosition(HomeActivity.finalRecentlyAddedTrackSearchResultList.get(position));
+                    LocalTrack track = HomeActivity.finalRecentlyAddedTrackSearchResultList.get(position);
+                    HomeActivity.localSelectedTrack = track;
+                    HomeActivity.streamSelected = false;
+                    HomeActivity.localSelected = true;
+                    HomeActivity.queueCall = false;
+                    HomeActivity.isReloaded = false;
+                    mCallback.onLocalTrackSelected(-1);
+                }
+
+                return true;
+            }
+
+            @Override
+            public boolean onLongClick(RecyclerView parent, View view, final int position, long id) {
+                if (position >= 0) {
+                    CustomLocalBottomSheetDialog localBottomSheetDialog = new CustomLocalBottomSheetDialog();
+                    localBottomSheetDialog.setPosition(position);
+                    localBottomSheetDialog.setLocalTrack(activity.finalRecentlyAddedTrackSearchResultList.get(position));
+                    localBottomSheetDialog.show(activity.getSupportFragmentManager(), "local_song_bottom_sheet");
+                }
+                return true;
+            }
+
+            @Override
+            public void onRequestDisallowInterceptTouchEvent(boolean disallowIntercept) {
+
+            }
+        });
+
+        Button mEndButton = new Button(getContext());
+        mEndButton.setBackgroundColor(HomeActivity.themeColor);
+        mEndButton.setTextColor(Color.WHITE);
+
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        mLayoutManager2.scrollToPositionWithOffset(0, 0);
+        new Handler().postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                playAllFAB.animate().scaleX(1.0f).scaleY(1.0f).setDuration(300).setInterpolator(new OvershootInterpolator());
+            }
+        }, 500);
+    }
+
+
+    public int getPosition(LocalTrack lt) {
+        for (int i = 0; i < HomeActivity.recentlyAddedTrackList.size(); i++) {
+            if (HomeActivity.recentlyAddedTrackList.get(i).getTitle().equals(lt.getTitle())) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        RefWatcher refWatcher = MusicDNAApplication.getRefWatcher(getContext());
+        refWatcher.watch(this);
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        RefWatcher refWatcher = MusicDNAApplication.getRefWatcher(getContext());
+        refWatcher.watch(this);
+    }
+
+    public void hidePlayAllFab() {
+        if (playAllFAB != null)
+            playAllFAB.setVisibility(View.INVISIBLE);
+    }
+
+    public void showPlayAllFab() {
+        if (playAllFAB != null)
+            playAllFAB.setVisibility(View.VISIBLE);
+    }
+
+    public void updateAdapter() {
+        if (adapter != null)
+            adapter.notifyDataSetChanged();
+    }
+
+}

--- a/app/src/main/res/layout/fragment_recently_added_songs.xml
+++ b/app/src/main/res/layout/fragment_recently_added_songs.xml
@@ -1,0 +1,43 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/colorDark"
+    android:clickable="true"
+    tools:context="com.sdsmdg.harjot.MusicDNA.fragments.LocalMusicFragments.RecentlyAddedSongsFragment">
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/recentlyAddedLocalMusicList"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_above="@+id/bottom_margin_layout"
+        android:layout_marginTop="3dp"
+        android:background="@color/colorDark" />
+
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/play_all_fab_local"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/bottom_margin_layout"
+        android:layout_alignParentRight="true"
+        android:layout_margin="16dp"
+        android:clickable="true"
+        android:scaleX="0.0"
+        android:scaleY="0.0"
+        android:src="@drawable/ic_play_arrow_white_48dp"
+        app:backgroundTint="#111111"
+        app:borderWidth="0dp"
+        app:elevation="6dp"
+        app:pressedTranslationZ="9dp"
+        app:rippleColor="#888888" />
+
+    <View
+        android:id="@+id/bottom_margin_layout"
+        android:layout_width="match_parent"
+        android:layout_height="65dp"
+        android:layout_alignParentBottom="true"
+        android:background="@color/colorDark"
+        android:clickable="true" />
+
+</RelativeLayout>


### PR DESCRIPTION
This PR adds a new fragment `Recent` 'to display the recently added local songs. It shows the songs in the descending order of dates. It also includes the `play all` FAB which makes a new queue with the order in accordance to the songs in the list and starts playing the first song.