### PR TITLE
Edit Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [<img src="https://f-droid.org/badge/get-it-on.png"
       alt="Get it on F-Droid"
       width="200">](https://android.izzysoft.de/repo/apk/com.sdsmdg.harjot.MusicDNA)<br>
-A Music Player for android that makes use of the Visualzer Class for rendering a beautiful **DNA** (***Visualization***) of the currently playing music.
+A Music Player for android that makes use of the Visualizer Class for rendering a beautiful **DNA** (***Visualization***) of the currently playing music.
 
 ## Background
 The Music Player draws inspiration from [paullewis's music-dna](https://github.com/paullewis/music-dna/).

--- a/app/src/main/java/org/jaudiotagger/audio/asf/data/AudioStreamChunk.java
+++ b/app/src/main/java/org/jaudiotagger/audio/asf/data/AudioStreamChunk.java
@@ -204,7 +204,7 @@ public final class AudioStreamChunk extends StreamChunk {
     }
 
     /**
-     * This mehtod returns whether the audio stream data is error concealed. <br>
+     * This method returns whether the audio stream data is error concealed. <br>
      * For now only interleaved concealment is known. <br>
      * 
      * @return <code>true</code> if error concealment is used.

--- a/app/src/main/java/org/jaudiotagger/audio/asf/data/EncryptionChunk.java
+++ b/app/src/main/java/org/jaudiotagger/audio/asf/data/EncryptionChunk.java
@@ -78,7 +78,7 @@ public class EncryptionChunk extends Chunk {
     }
 
     /**
-     * This method returns a collection of all {@link String}s which were addid
+     * This method returns a collection of all {@link String}s which were added
      * due {@link #addString(String)}.
      * 
      * @return Inserted Strings.

--- a/app/src/main/java/org/jaudiotagger/audio/asf/data/FileHeader.java
+++ b/app/src/main/java/org/jaudiotagger/audio/asf/data/FileHeader.java
@@ -59,7 +59,7 @@ public class FileHeader extends Chunk {
     private final long maxPackageSize;
 
     /**
-     * Minimun size of stream packages. <br>
+     * Minimum size of stream packages. <br>
      * <b>Warning: </b> must be same size as {@link #maxPackageSize}. Its not
      * known how to handle deviating values.
      */

--- a/app/src/main/java/org/jaudiotagger/audio/asf/data/MetadataDescriptor.java
+++ b/app/src/main/java/org/jaudiotagger/audio/asf/data/MetadataDescriptor.java
@@ -96,7 +96,7 @@ public class MetadataDescriptor implements Comparable<MetadataDescriptor>,
     public final static int TYPE_GUID = 6;
 
     /**
-     * Constant for the metadata descriptor-type for QWORD (64-bit unsinged). <br>
+     * Constant for the metadata descriptor-type for QWORD (64-bit unsigned). <br>
      */
     public final static int TYPE_QWORD = 4;
 

--- a/app/src/main/java/org/jaudiotagger/audio/asf/io/ContentDescriptionReader.java
+++ b/app/src/main/java/org/jaudiotagger/audio/asf/io/ContentDescriptionReader.java
@@ -91,7 +91,7 @@ public class ContentDescriptionReader implements ChunkReader {
         final int[] stringSizes = getStringSizes(stream);
 
         /*
-         * Now we know the String length of each occuring String.
+         * Now we know the String length of each occurring String.
          */
         final String[] strings = new String[stringSizes.length];
         for (int i = 0; i < strings.length; i++) {

--- a/app/src/main/java/org/jaudiotagger/audio/asf/io/StreamBitratePropertiesReader.java
+++ b/app/src/main/java/org/jaudiotagger/audio/asf/io/StreamBitratePropertiesReader.java
@@ -43,7 +43,7 @@ public class StreamBitratePropertiesReader implements ChunkReader {
      * Should not be used for now.
      */
     protected StreamBitratePropertiesReader() {
-        // NOTHING toDo
+        // Nothing to Do
     }
 
     /**


### PR DESCRIPTION
"A Music Player for android that makes use of the Visualzer Class for rendering a beautiful **DNA** (***Visualization***) of of the current playing music" on README.md has an error at 'Visualzer', so we modified it to "Visualizer".